### PR TITLE
Add two additional columns to results gpkg

### DIFF
--- a/hydamo_validation/logical_validation.py
+++ b/hydamo_validation/logical_validation.py
@@ -12,6 +12,8 @@ SUMMARY_COLUMNS = [
     "invalid",
     "invalid_critical",
     "invalid_non_critical",
+    "invalid_auto_fixable",
+    "invalid_manual_fixable",
     "ignored",
     "summary",
     "tags_assigned",
@@ -93,6 +95,7 @@ def gdf_add_summary(
     critical,
     tags,
     tags_indices,
+    auto_fixable=False,
     separator=LIST_SEPARATOR,
 ):
     gdf.loc[gdf[variable] == False, "rating"] -= penalty
@@ -106,6 +109,15 @@ def gdf_add_summary(
         gdf.loc[gdf[variable] == False, "invalid_non_critical"] += (
             f"{rule_id}{separator}"
         )
+    if auto_fixable:
+        gdf.loc[gdf[variable] == False, "invalid_auto_fixable"] += (
+            f"{rule_id}{separator}"
+        )
+    else:
+        gdf.loc[gdf[variable] == False, "invalid_manual_fixable"] += (
+            f"{rule_id}{separator}"
+        )
+
     if tags is not None:
         gdf.loc[tags_indices, ("tags_assigned")] += f"{tags}{separator}"
         gdf.loc[gdf[variable] == False, "tags_invalid"] += f"{tags}{separator}"
@@ -316,6 +328,8 @@ def execute(
                 else:
                     tags = None
 
+                auto_fixable = rule.get("auto_fixable", False)
+
                 exceptions += filter_indices
                 _valid_indices = object_gdf[~object_gdf.index.isna()].index
                 tags_indices = [i for i in _valid_indices if i not in exceptions]
@@ -328,6 +342,7 @@ def execute(
                     critical=critical,
                     tags=tags,
                     tags_indices=tags_indices,
+                    auto_fixable=auto_fixable,
                 )
 
             except Exception as e:

--- a/hydamo_validation/summaries.py
+++ b/hydamo_validation/summaries.py
@@ -86,7 +86,7 @@ class LayersSummary:
             setattr(
                 self,
                 layer,
-                results_gdf.join(gdf),
+                results_gdf.join(gdf, how="left", rsuffix="_right"),
             )
 
     def export(self, results_path, output_types=OUTPUT_TYPES):


### PR DESCRIPTION
Changes for validation viewer, this ticket: https://github.com/threedi/hhnk-threedi-tools/issues/293

It works together with changes in the validation rules JSON (PR in hhnk-threedi-tools repo: https://github.com/threedi/hhnk-threedi-tools/pull/315).

We've added two columns invalid_auto_fixable and invalid_manual_fixable which will be used in QGIS validation viewer to order and symbolize the validation results on the map.

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/3b0a3e29-3713-4130-9062-1628f9028e0a" />
